### PR TITLE
Solution for bug 698013 for documentdashboard page flyout close on click on maindiv.

### DIFF
--- a/tree/master/cloud/src/solution/Microsoft.Legal.MatterCenter.Web/wwwroot/app/dashboard/documentdashboard.html
+++ b/tree/master/cloud/src/solution/Microsoft.Legal.MatterCenter.Web/wwwroot/app/dashboard/documentdashboard.html
@@ -7,7 +7,7 @@
     </a>
 </div>
 <div class="popupContainerBackground hide"></div>
-<div id="mainDivContainer">
+<div id="mainDivContainer" ng-click="vm.closealldrops($event)" >
     <div class="matterPopup"></div>
     <div class="documentPopup"></div>
     <div class="clear"></div>


### PR DESCRIPTION
Search Document flyout not closing when we click outside of search flyout. After binding event it is working fine in documentdashboard page. For more info refere bug 698013.